### PR TITLE
Revise getLikesPage, getUserProfile. Fix followships route in likes and profile handlebars

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -48,10 +48,10 @@ const userController = {
         Tweet,
         { model: User, as: 'Followers' },
         { model: User, as: 'Followings' },
-        { model: Tweet, as: 'LikedTweets', include: [User] }
+        { model: Tweet, as: 'LikedTweets', include: [User, Reply, { model: User, as: 'LikedUsers' }] }
       ]
     }).then(user => {
-      const isFollowed = user.Followers.map(d => d.id).includes(user.id)
+      const isFollowed = user.Followings.map(d => d.id).includes(req.user.id)
       const likedList = user.LikedTweets.map(liked => ({
         ...liked.dataValues
       }))
@@ -158,13 +158,14 @@ const userController = {
         { model: Tweet, as: 'LikedTweets' }
       ]
     }).then(user => {
+      const isFollowed = user.Followings.map(d => d.id).includes(req.user.id)
       const tweets = user.Tweets.map(a => ({
         ...a.dataValues,
         description: a.dataValues.description.substring(0, 100),
         isReplied: req.user.Replies.map(r => r.id).includes(a.id),
         isLiked: req.user.LikedTweets.map(l => l.id).includes(a.id)
       }))
-      return res.render('profile', { user, tweets })
+      return res.render('profile', { user, tweets, isFollowed })
     })
   },
 

--- a/views/likes.handlebars
+++ b/views/likes.handlebars
@@ -31,7 +31,7 @@
         <button type="submit" class="Button-secondary">Unfollow</button>
       </form>
       {{else}}
-      <form action="/followships/{{user.id}}" method="POST">
+      <form action="/followships" method="POST">
         <button type="submit" class="Button-secondary">Follow</button>
       </form>
       {{/if}}
@@ -54,6 +54,26 @@
 
       <div class="col-right">
         <p>{{this.description}}</p>
+        <div class="reaction">
+          <a href="/tweets/{{this.UserId}}/replies">
+            {{#if isReplied}}
+            <i class="fas fa-comment"></i>
+            {{else}}
+            <i class="far fa-comment"></i>
+            {{/if}}
+            &nbsp;&nbsp;{{this.Replies.length}}</a>
+
+
+          {{#if isLiked}}
+          <form action="/tweets/{{this.UserId}}/unlike" method="POST">
+            <button type="submit"><i class="fas fa-heart"></i>
+              {{else}}
+              <form action="/tweets/{{this.UserId}}/like" method="POST">
+                <button type="submit"><i class="far fa-heart"></i>
+                  {{/if}}
+                  &nbsp;&nbsp;{{this.LikedUsers.length}}</button>
+              </form>
+        </div>
       </div>
     </div>
     {{/each}}

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -55,7 +55,7 @@
               <button type="submit" class="Button-secondary">Unfollow</button>
             </form>
             {{else}}
-            <form action="/followships/{{user.id}}" method="POST">
+            <form action="/followships" method="POST">
               <button type="submit" class="Button-secondary">Follow</button>
             </form>
             {{/if}}


### PR DESCRIPTION
大神安安，今天最後一push請笑納<(_ _)>
其實只有做小小的修改
1. 話說因為likes頁面跟profile頁面的follow/unfollow又抽筋，所以有試著改了下userController中的getLikesPage跟getUserProfile((只是問題還沒解決，時好時壞
2. likes頁面跟profile頁面的「新增一筆 followship 記錄」功能的路由改為規定的 /followships (把後面的:id拿掉)

感恩感恩~辛苦了//